### PR TITLE
Cleaning up the navigation of the app

### DIFF
--- a/App.js
+++ b/App.js
@@ -12,42 +12,36 @@ import CompleteChallengeModal from './Components/CompleteChallengeModal';
 const Stack = createStackNavigator();
 const Drawer = createDrawerNavigator();
 
-export const HomeLoaded = () => {
-  return (
-    <Stack.Navigator initialRouteName='Landing' headerMode='none'>
-      <Stack.Screen
-        name="Landing"
-        component={LandingPage}
-      />
-      <Stack.Screen
-        name="Home"
-        component={Home}
-      />
-      <Stack.Screen
-        name="Main Page"
-        component={MainPage}
-      />
-      <Stack.Screen
-        name="Sign Up"
-        component={SignUp}
-      />
-      <Stack.Screen
-        name="MyModal"
-        component={CompleteChallengeModal}
-      >
-      </Stack.Screen>
-    </Stack.Navigator>
-  )
-}
+
 
 export default class App extends Component {
 
   render() {
     return (
       <NavigationContainer>
-        <Drawer.Navigator initialRouteName='HomeLoaded'>
-          <Drawer.Screen name='HomeLoaded' component={HomeLoaded}></Drawer.Screen>
-        </Drawer.Navigator>
+        <Stack.Navigator initialRouteName='Landing' headerMode='none'>
+          <Stack.Screen
+            name="Landing"
+            component={LandingPage}
+          />
+          <Stack.Screen
+            name="Home"
+            component={Home}
+          />
+          <Stack.Screen
+            name="Main Page"
+            component={MainPage}
+          />
+          <Stack.Screen
+            name="Sign Up"
+            component={SignUp}
+          />
+          <Stack.Screen
+            name="MyModal"
+            component={CompleteChallengeModal}
+          >
+          </Stack.Screen>
+        </Stack.Navigator>
       </NavigationContainer>
     );
   }

--- a/Components/MainPage.js
+++ b/Components/MainPage.js
@@ -176,15 +176,10 @@ const MainPage = () => {
 }
 
 const LogOut = ({ navigation }) => {
+  navigation.navigate('Landing')
 
-  React.useEffect(() => {
-    navigation.navigate('HomeLoaded',
-      {
-        screen: 'Landing'
-      })
-  }, [])
   return (
-    <View></View>
+    <></>
   )
 }
 

--- a/Components/YourChallenges.js
+++ b/Components/YourChallenges.js
@@ -115,9 +115,7 @@ class YourChallenges extends Component {
         const challengeId = id
         const userChallengeIdObject = this.state.allUserChallenges.find(id => id.challenge == challengeId)
         await AsyncStorage.setItem('userChallengeId', JSON.stringify(userChallengeIdObject.id))
-        this.props.navigation.navigate('HomeLoaded', {
-                screen: "MyModal"
-            })
+        this.props.navigation.navigate('MyModal')
     }
 
     render() {


### PR DESCRIPTION
Removed the drawer navigator and re-routed the navigation based on the HomeLoaded component from App.js to render the stack navigator in the App directly under NavigationContainer.